### PR TITLE
Strip package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 upgrade-requirements.py
 =======================
-[![Current version on PyPI](http://img.shields.io/pypi/v/upgrade-requirements.svg)](http://pypi.python.org/pypi/upgrade-requirements/)
+[![Current version on PyPI](https://img.shields.io/pypi/v/upgrade-requirements.svg)](https://pypi.python.org/pypi/upgrade-requirements/)
 
 Upgrade all your outdated `requirements.txt` in a single command.
 

--- a/upgrade_requirements.py
+++ b/upgrade_requirements.py
@@ -13,7 +13,7 @@ def get_installed_requirement(entry):
     installed_name, installed_version = None, None
 
     name = entry.split('[', 1)[0]
-    info = (subprocess.check_output(['pip', 'show', name])
+    info = (subprocess.check_output(['pip', 'show', name.strip()])
             .decode('utf-8', 'replace'))
     for line in info.split('\n'):
         line = line.strip()


### PR DESCRIPTION
if requirements file has empty like below
```
aaa == 1.0.0
```
`upgrade-requirements` will throw exception
```
Collecting installed versions...
Traceback (most recent call last):
File "/usr/local/bin/upgrade-requirements", line 11, in <module>
sys.exit(main())
File "/usr/local/lib/python3.5/dist-packages/upgrade_requirements.py", line 72, in main
installed_name, installed_version = get_installed_requirement(name)
File "/usr/local/lib/python3.5/dist-packages/upgrade_requirements.py", line 16, in get_installed_requirement
info = (subprocess.check_output(['pip', 'show', name])
File "/usr/lib/python3.5/subprocess.py", line 316, in check_output
**kwargs).stdout
File "/usr/lib/python3.5/subprocess.py", line 398, in run
output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['pip', 'show', 'aaa ']' returned non-zero exit status 1
```