### PR TITLE
Add Support for '>=' Specifier

### DIFF
--- a/upgrade_requirements.py
+++ b/upgrade_requirements.py
@@ -60,7 +60,11 @@ def main(args=None):
         # TODO: Handle other version instructions
         if '==' not in requirement:
             print('Error: Can only work with pinned requirements for now.')
-        name, version = requirement.split('==')
+        name_version = requirement.split('==')
+        if len(name_version) == 2:
+            name, version = name_version
+        else:
+            name, version = requirement.split('>=')
         upgrades.append(name)
 
     # Edge case


### PR DESCRIPTION
I added a temp variable `name_version` which stores the result of `requirement.split('==')`.

If the requirement contains '>=', then it will raise an Exception that tuple of length 1 can't be unpacked. For fixing this issue, I checked If the length of `requirement.split('==')` is not equal to 2, then split on basis of '>='.

I tested the above solution on a requirements.txt file which contains both '>=' and '==' specifiers and it worked out for me.